### PR TITLE
UIGraPhicsContext bug

### DIFF
--- a/Olla4iOS/foundation/addtions/UIImage+Resize.m
+++ b/Olla4iOS/foundation/addtions/UIImage+Resize.m
@@ -25,7 +25,6 @@
 //eg 640*1136 , 以宽为准，高度等比例缩放
 - (UIImage *)resizeAspectImageWithSize:(CGSize)size{
 
-    UIGraphicsBeginImageContext(size);
 
     CGFloat widthScale = size.width/self.size.width; // 以宽为准
     CGFloat height = widthScale * self.size.height;//


### PR DESCRIPTION
这个方法有问题,因为调用了两次UIGraphicsBeginImageContext(),这方法会将当前上下文入栈.当我异步绘制的时候会出现上下文出栈入栈死循环.
